### PR TITLE
キャライベントを選択肢から識別時に共通イベントが選択中の育成ウマ娘から取得されるよう修正

### DIFF
--- a/UmaUmaChecker/EventData.cpp
+++ b/UmaUmaChecker/EventData.cpp
@@ -128,7 +128,7 @@ std::shared_ptr<EventSource> EventData::RetrieveTitle(const std::wstring& title,
 	}
 }
 
-std::shared_ptr<EventSource> EventData::RetrieveOption(const std::wstring& option)
+std::shared_ptr<EventSource> EventData::RetrieveOption(const std::wstring& option, EventRoot* root)
 {
 	std::vector<std::wstring> xstrs;
 
@@ -147,6 +147,10 @@ std::shared_ptr<EventSource> EventData::RetrieveOption(const std::wstring& optio
 
 	const auto& event = OptionMap.find(match);
 	if (event == OptionMap.end()) return nullptr;
+	else if (root) {
+		const auto exactEvent = root->Events.find(event->second->Name);
+		if (exactEvent != root->Events.end()) return exactEvent->second;
+	}
 
 	return event->second;
 }

--- a/UmaUmaChecker/EventData.h
+++ b/UmaUmaChecker/EventData.h
@@ -20,7 +20,7 @@ public:
 	bool Load(const std::wstring& path);
 
 	std::shared_ptr<EventSource> RetrieveTitle(const std::wstring& title, EventRoot* root = nullptr);
-	std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option);
+	std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option, EventRoot* root = nullptr);
 	std::shared_ptr<EventRoot> RetrieveName(const std::wstring& name);
 	std::shared_ptr<EventRoot> GetName(const std::wstring& name);
 

--- a/UmaUmaChecker/Uma.cpp
+++ b/UmaUmaChecker/Uma.cpp
@@ -610,15 +610,15 @@ std::shared_ptr<EventSource> Uma::GetCharaEventByBottomOption(const cv::Mat& src
 	std::wstring text = GetTextFromImage(bin);
 	if (!text.empty()) {
 		ChangeCollectedText(text);
-		auto event = EventLib.CharaEvent.RetrieveOption(text);
-		if (event) return event;
+		auto event = EventLib.CharaEvent.RetrieveOption(text, CurrentCharacter);
+		return event;
 	}
 
 	text = GetTextFromImage(gray);
 	if (!text.empty()) {
 		ChangeCollectedText(text);
-		auto event = EventLib.CharaEvent.RetrieveOption(text);
-		if (event) return event;
+		auto event = EventLib.CharaEvent.RetrieveOption(text, CurrentCharacter);
+		return event;
 	}
 
 	return nullptr;


### PR DESCRIPTION
選択肢名から識別した際に共通イベントは選択キャラクターのイベントとなるよう、イベント名からCurrentCharacterのイベントを取得する