### PR TITLE
キャライベントを選択肢から識別時に共通イベントが選択中の育成ウマ娘から取得されるよう修正

### DIFF
--- a/UmaUmaChecker/Event.h
+++ b/UmaUmaChecker/Event.h
@@ -24,5 +24,6 @@ class EventRoot
 public:
 	std::wstring Name;
 	std::unordered_map<std::wstring, std::shared_ptr<EventSource>> Events;
+	std::unordered_map<std::wstring, std::shared_ptr<EventSource>> OptionMap;
 };
 

--- a/UmaUmaChecker/EventData.cpp
+++ b/UmaUmaChecker/EventData.cpp
@@ -51,6 +51,10 @@ bool EventData::Load(const std::wstring& path)
 							if (OptionMap.find(choise->Title) == OptionMap.end()) {
 								OptionMap[choise->Title] = event;
 							}
+
+							if (skill->OptionMap.find(choise->Title) == skill->OptionMap.end()) {
+								skill->OptionMap[choise->Title] = event;
+							}
 						}
 
 						std::wstring EventName = utility::from_u8string(choise.key());
@@ -145,12 +149,15 @@ std::shared_ptr<EventSource> EventData::RetrieveOption(const std::wstring& optio
 		match = GetBestMatchString(xstrs, option);
 	}
 
+	if (root) {
+		auto event = root->OptionMap.find(match);
+		if (event != root->OptionMap.end()) {
+			return event->second;
+		}
+	}
+
 	const auto& event = OptionMap.find(match);
 	if (event == OptionMap.end()) return nullptr;
-	else if (root) {
-		const auto exactEvent = root->Events.find(event->second->Name);
-		if (exactEvent != root->Events.end()) return exactEvent->second;
-	}
 
 	return event->second;
 }


### PR DESCRIPTION
キャライベントの選択肢から関係ないキャラのイベントが読み込まれる問題を修正