### PR TITLE
「output.log にデバッグログを出力する」を有効の場合、識別されたイベント名をログに書き込む

### DIFF
--- a/UmaUmaChecker/Uma.cpp
+++ b/UmaUmaChecker/Uma.cpp
@@ -630,6 +630,7 @@ EventSource* Uma::DetectEvent(const cv::Mat& srcImg, uint64* pHash, std::vector<
 	if (pHash) *pHash = 0;
 
 	uint64 hash = 0;
+	Config* config = Config::GetInstance();
 
 	// サポートカードイベント
 	std::vector<std::wstring> events = RecognizeCardEventText(srcImg, &hash);
@@ -640,6 +641,7 @@ EventSource* Uma::DetectEvent(const cv::Mat& srcImg, uint64* pHash, std::vector<
 
 		auto event = GetCardEvent(events);
 		if (!event) event = GetEventByBottomOption(srcImg);
+		if (config->EnableDebug && event) LOG_DEBUG << L"[サポートカード] イベント名: " << event->Name;
 		return event.get();
 	}
 
@@ -652,6 +654,7 @@ EventSource* Uma::DetectEvent(const cv::Mat& srcImg, uint64* pHash, std::vector<
 
 			auto event = GetCharaEvent(events);
 			if (!event) event = GetCharaEventByBottomOption(srcImg);
+			if (config->EnableDebug && event) LOG_DEBUG << L"[育成ウマ娘] イベント名: " << event->Name;
 			return event.get();
 		}
 	}
@@ -664,6 +667,7 @@ EventSource* Uma::DetectEvent(const cv::Mat& srcImg, uint64* pHash, std::vector<
 
 		auto event = GetScenarioEvent(events);
 		if (!event) event = GetScenarioEventByBottomOption(srcImg);
+		if (config->EnableDebug && event) LOG_DEBUG << L"[シナリオイベント] イベント名: " << event->Name;
 		return event.get();
 	}
 


### PR DESCRIPTION
#73 実装