### PR TITLE
イベントの選択肢が特定のウィンドウサイズで読み取れない問題を修正

### DIFF
--- a/UmaUmaChecker/Event.h
+++ b/UmaUmaChecker/Event.h
@@ -27,3 +27,9 @@ public:
 	std::unordered_map<std::wstring, std::shared_ptr<EventSource>> OptionMap;
 };
 
+
+class BaseData {
+public:
+	virtual std::shared_ptr<EventSource> RetrieveTitle(const std::wstring& title, EventRoot* root = nullptr) = 0;
+	virtual std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option, EventRoot* root = nullptr) = 0;
+};

--- a/UmaUmaChecker/EventData.h
+++ b/UmaUmaChecker/EventData.h
@@ -11,7 +11,7 @@ namespace simstring {
 	class reader;
 }
 
-class EventData
+class EventData : public BaseData
 {
 public:
 	EventData();
@@ -19,8 +19,8 @@ public:
 
 	bool Load(const std::wstring& path);
 
-	std::shared_ptr<EventSource> RetrieveTitle(const std::wstring& title, EventRoot* root = nullptr);
-	std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option, EventRoot* root = nullptr);
+	std::shared_ptr<EventSource> RetrieveTitle(const std::wstring& title, EventRoot* root = nullptr) override;
+	std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option, EventRoot* root = nullptr) override;
 	std::shared_ptr<EventRoot> RetrieveName(const std::wstring& name);
 	std::shared_ptr<EventRoot> GetName(const std::wstring& name);
 

--- a/UmaUmaChecker/ScenarioData.cpp
+++ b/UmaUmaChecker/ScenarioData.cpp
@@ -82,21 +82,13 @@ std::shared_ptr<EventSource> ScenarioData::RetrieveTitle(const std::wstring& tit
 
 	std::wstring match = xstrs.front();
 
-	if (root) {
-		auto event = root->Events.find(match);
-		if (event == root->Events.end()) return nullptr;
+	auto event = EventMap.find(match);
+	if (event == EventMap.end()) return nullptr;
 
-		return event->second;
-	}
-	else {
-		auto event = EventMap.find(match);
-		if (event == EventMap.end()) return nullptr;
-
-		return event->second;
-	}
+	return event->second;
 }
 
-std::shared_ptr<EventSource> ScenarioData::RetrieveOption(const std::wstring& option)
+std::shared_ptr<EventSource> ScenarioData::RetrieveOption(const std::wstring& option, EventRoot* root)
 {
 	std::vector<std::wstring> xstrs;
 

--- a/UmaUmaChecker/ScenarioData.h
+++ b/UmaUmaChecker/ScenarioData.h
@@ -11,7 +11,7 @@ namespace simstring {
 	class reader;
 }
 
-class ScenarioData
+class ScenarioData : public BaseData
 {
 public:
 	ScenarioData();
@@ -19,8 +19,8 @@ public:
 
 	bool Load(const std::wstring& path);
 
-	std::shared_ptr<EventSource> RetrieveTitle(const std::wstring& title, EventRoot* root = nullptr);
-	std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option);
+	std::shared_ptr<EventSource> RetrieveTitle(const std::wstring& title, EventRoot* root = nullptr) override;
+	std::shared_ptr<EventSource> RetrieveOption(const std::wstring& option, EventRoot* root = nullptr) override;
 
 private:
 	void InitDB(const std::filesystem::path& path);

--- a/UmaUmaChecker/Tesseract.h
+++ b/UmaUmaChecker/Tesseract.h
@@ -14,6 +14,7 @@ public:
 	static void Initialize();
 	static void Uninitialize();
 
+	static std::wstring RecognizeAsRaw(const cv::Mat& image);
 	static std::wstring Recognize(const cv::Mat& image);
 
 private:

--- a/UmaUmaChecker/Uma.h
+++ b/UmaUmaChecker/Uma.h
@@ -56,6 +56,8 @@ private:
 	std::shared_ptr<EventSource> GetCardEvent(const std::vector<std::wstring>& text_list);
 	std::shared_ptr<EventSource> GetCharaEvent(const std::vector<std::wstring>& text_list);
 	std::shared_ptr<EventSource> GetScenarioEvent(const std::vector<std::wstring>& text_list);
+
+	std::shared_ptr<EventSource> RecognizeBottomOption(const cv::Mat& srcImg, BaseData* data, EventRoot* root = nullptr);
 	std::shared_ptr<EventSource> GetEventByBottomOption(const cv::Mat& srcImg);
 	std::shared_ptr<EventSource> GetCharaEventByBottomOption(const cv::Mat& srcImg);
 	std::shared_ptr<EventSource> GetScenarioEventByBottomOption(const cv::Mat& srcImg);

--- a/UmaUmaChecker/UmaTripRecognizer.cpp
+++ b/UmaUmaChecker/UmaTripRecognizer.cpp
@@ -67,7 +67,7 @@ bool UmaTripRecognizer::Detect(cv::Mat& src, std::vector<std::wstring>& vec)
 		double black_ratio = (bin.size().area() - cv::countNonZero(bin)) / (double)bin.size().area();
 
 		if (black_ratio > 0.01) {
-			std::wstring name = Tesseract::Recognize(bin);
+			std::wstring name = Tesseract::RecognizeAsRaw(bin);
 			vec.push_back(name);
 		}
 	}


### PR DESCRIPTION
### 概要
Tesseractのページモードが`PSM_RAW_LINE`だとイベント名は読み取れるが、選択肢の読み取り精度が悪い。
なので、`PSM_SINGLE_LINE`で識別する処理を追加。
処理の順番は以下の通り:

1. 2値化画像を`PSM_SINGLE_LINE`で読み取り
2. 2値化画像を`PSM_RAW_LINE`で読み取り
3. グレースケール画像を`PSM_SINGLE_LINE`で読み取り
4. 識別できなければ`nullptr`を返す。