### PR TITLE
ステータスバーが正しく動作するように修正

### DIFF
--- a/UmaUmaChecker/MainFrame.cpp
+++ b/UmaUmaChecker/MainFrame.cpp
@@ -33,7 +33,7 @@
 using json = nlohmann::json;
 
 
-MainFrame::MainFrame(wxWindow* parent, const wxPoint& pos, const wxSize& size, long style) : ThemedWindowWrapper<wxFrame>(parent, wxID_ANY, app_title, pos, size, style), umaMgr(new Uma(this)), m_PreviewWindow(NULL), timer(this)
+MainFrame::MainFrame(wxWindow* parent, const wxPoint& pos, const wxSize& size, long style) : ThemedWindowWrapper<wxFrame>(parent, wxID_ANY, app_title, pos, size, style), umaMgr(new Uma(this)), m_PreviewWindow(NULL)
 {
 	Config* config = Config::GetInstance();
 
@@ -375,6 +375,7 @@ void MainFrame::OnClickSetting(wxCommandEvent& event)
 		}
 		else if (!timer.IsRunning()) {
 			m_statusBar->Show();
+			PositionStatusBar();
 			timer.Start(1000);
 		}
 
@@ -399,8 +400,9 @@ void MainFrame::OnClickSetting(wxCommandEvent& event)
 		for (auto ctrl : m_textCtrlEventOptions) {
 			ctrl->SetHeightByLine(config->OptionMaxLine);
 		}
-		Layout();
+
 		Fit();
+		Layout();
 		Refresh();
 	}
 


### PR DESCRIPTION
ステータスバーが表示されてない状態で、設定によってステータスバーを表示するようにすると表示が崩れる問題を修正。
ステータスバーを表示しても値が更新されない問題を修正。